### PR TITLE
feat: make Webpack compile both client and server apps

### DIFF
--- a/internals/babel/.babelrc.js
+++ b/internals/babel/.babelrc.js
@@ -9,22 +9,6 @@ module.exports = {
       ]
     }
   },
-  "plugins": [
-    [ 
-      "module-resolver", 
-      {
-        "alias": {
-          '@actions': "./dist/client/state/actions",
-          "@client": "./dist/client",
-          "@config": "./dist/client/config",
-          "@constants": "./dist/client/constants",
-          "@containers": "./dist/client/containers",
-          "@components": "./dist/client/components",
-          "@modules": "./dist/client/modules",
-        },
-      }
-    ]
-  ],
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react",

--- a/internals/gulp/gulpfile.js
+++ b/internals/gulp/gulpfile.js
@@ -45,16 +45,6 @@ gulp.task('clean:server', () => {
   ]);
 });
 
-// gulp.task('copy', () => {
-//   console.info('[copy] src: %s, tgt: %s', SERVER_SRC_PATH, BUILD_PATH);
-
-//   return gulp.src([
-//     `${SERVER_SRC_PATH}/**/*`,
-//     `!${SERVER_SRC_PATH}/**/*.js`,
-//   ])
-//     .pipe(gulp.dest(BUILD_PATH));
-// });
-
 gulp.task('emptylog', () => {
   console.info('[emptylog] LOG_PATH: %s', LOG_PATH);
 
@@ -63,13 +53,12 @@ gulp.task('emptylog', () => {
   ]);
 });
 
-gulp.task('webpack:client', (done) => {
-  const entrypointBundles = [];
-  const webpackConfig = require('../webpack/webpack.config.dev.web');
+gulp.task('webpack:client:prod', (done) => {
+  const webpackConfig = require('../webpack/webpack.config.client.prod.web');
   const compiler = webpack(webpackConfig);
 
   compiler.run((err, stats) => {
-    console.info('[webpack:client] webpack configuration:\n%o\n', webpackConfig);
+    console.info('[webpack:client:prod] webpack configuration:\n%o\n', webpackConfig);
     if (err || stats.hasErrors()) {
       console.error(stats.toString('erros-only'));
     } else {
@@ -79,12 +68,34 @@ gulp.task('webpack:client', (done) => {
         builtAt: true,
         entrypoints: true,
       });
-      console.info('[webpack:client] compilation success:\n%o\n', info);
+      console.info('[webpack:client:prod] compilation success:\n%o\n', info);
       fs.writeFileSync(`${DIST_BUNDLE_PATH}/build.json`, JSON.stringify(info));
     }
     done();
   });
 });
 
-gulp.task('build:client', gulp.series('clean:client', 'webpack:client'));
-gulp.task('build:server', gulp.series('clean:server', 'babel'));
+gulp.task('webpack:server:prod', (done) => {
+  const webpackConfig = require('../webpack/webpack.config.server.prod');
+  const compiler = webpack(webpackConfig);
+
+  compiler.run((err, stats) => {
+    console.info('[webpack:server:prod] webpack configuration:\n%o\n', webpackConfig);
+    if (err || stats.hasErrors()) {
+      console.error(stats.toString('erros-only'));
+    } else {
+      const info = stats.toJson({
+        all: false,
+        assets: true,
+        builtAt: true,
+        entrypoints: true,
+      });
+      console.info('[webpack:server:prod] compilation success:\n%o\n', info);
+      // fs.writeFileSync(`${DIST_BUNDLE_PATH}/build.json`, JSON.stringify(info));
+    }
+    done();
+  });
+});
+
+gulp.task('build:client', gulp.series('clean:client', 'webpack:client:prod'));
+gulp.task('build:server', gulp.series('clean:server', 'webpack:server:prod'));

--- a/internals/webpack/paths.js
+++ b/internals/webpack/paths.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+module.exports = {
+  distBundlePath: path.resolve(__dirname, '../../dist/bundle'),
+};

--- a/internals/webpack/webpack.config.client.dev.web.js
+++ b/internals/webpack/webpack.config.client.dev.web.js
@@ -2,17 +2,17 @@ const path = require('path');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 
-const config  = require('./webpack.config.web');
-const APP_PATH = path.resolve(__dirname, '../../src/app');
+const config  = require('./webpack.config.client.web');
+const CLIENT_PATH = path.resolve(__dirname, '../../src/client');
 
 const devConfig = {
   devtool: 'source-map',
-  // entry: {
-  //   app: [ 
-  //     'webpack-hot-middleware/client', 
-  //     path.resolve(APP_PATH, 'client.jsx'),
-  //   ],
-  // },
+  entry: {
+    app: [ 
+      'webpack-hot-middleware/client', 
+      path.resolve(CLIENT_PATH, 'client.jsx'),
+    ],
+  },
   mode: 'development',
   optimization: {
     minimize: false,

--- a/internals/webpack/webpack.config.client.prod.web.js
+++ b/internals/webpack/webpack.config.client.prod.web.js
@@ -2,7 +2,7 @@ const merge = require('webpack-merge');
 const path = require('path');
 const webpack = require('webpack');
 
-const config  = require('./webpack.config.web');
+const config  = require('./webpack.config.client.web');
 const APP_PATH = path.resolve(__dirname, '../../src/app');
 
 const prodConfig = {

--- a/internals/webpack/webpack.config.client.web.js
+++ b/internals/webpack/webpack.config.client.web.js
@@ -1,4 +1,4 @@
-const htmlWebpackPlugin = require('html-webpack-plugin')
+const htmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 const babelRc = require('../babel/.babelrc');

--- a/internals/webpack/webpack.config.server.prod.js
+++ b/internals/webpack/webpack.config.server.prod.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const webpack = require('webpack');
+const merge = require('webpack-merge');
+const nodeExternals = require('webpack-node-externals');
+
+const config  = require('./webpack.config.client.web');
+const CLIENT_PATH = path.resolve(__dirname, '../../src/client');
+const SERVER_PATH = path.resolve(__dirname, '../../src/server');
+const DIST_SERVER_PATH = path.resolve(__dirname, '../../dist/server');
+
+const serverProdConfig = {
+  devtool: 'source-map',
+  entry: {
+    server: [
+      path.resolve(SERVER_PATH, 'server.prod.js'),
+    ],
+  },
+  externals: [
+    nodeExternals({
+      whitelist: /\.css$/,
+    }),
+  ],
+  mode: 'development',
+  optimization: {
+    minimize: false,
+  },
+  output: {
+    path: DIST_SERVER_PATH,
+    filename: '[name].[hash].js',
+    publicPath: '/',
+  },
+  stats: {
+    colors: true,
+  },
+  target: 'node',
+};
+
+module.exports = Object.assign(config, serverProdConfig);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "webpack": "^4.1.1",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-hot-middleware": "^2.21.2",
-    "webpack-merge": "^4.1.1"
+    "webpack-merge": "^4.1.1",
+    "webpack-node-externals": "^1.7.2"
   },
   "license": "MIT",
   "main": "",
@@ -64,10 +65,9 @@
     "build:server": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server",
     "build:client": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:client",
     "lint": "./node_modules/.bin/eslint ./src",
-    "start:local": "NODE_ENV=local node ./src/server/server.js",
-    "start:prod": "NODE_ENV=production node ./src/server/server.js",
-    "start:ssr": "npm-run-all --parallel build:server build:client && node ./dist/server/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start:local": "NODE_ENV=development npm-run-all --parallel build:server build:client && node ./dist/server/server.js",
+    "start:prod": "NODE_ENV=production npm-run-all --parallel build:server build:client && node ./dist/server/server.prod.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
   },
   "version": "0.0.1"
 }

--- a/src/client/client.jsx
+++ b/src/client/client.jsx
@@ -7,7 +7,6 @@ import * as ReactDOM from 'react-dom';
 import appConfig from '@config/appConfig';
 import configureStore from '@client/state/configureStore';
 import RootContainer from '@containers/app/RootContainer/RootContainer.web';
-import Layout from '@client/Layout.web';
 
 // import Logger from '@modules/Logger';
 
@@ -21,48 +20,48 @@ import Layout from '@client/Layout.web';
   }
 })();
 
-// (async function asyncInitRenderingAfterPolyfill() {
-//   const rootEl = document.getElementById('app-root');
+// // (async function asyncInitRenderingAfterPolyfill() {
+// //   const rootEl = document.getElementById('app-root');
   
-//   const [
-//     configureStore,
-//     RootContainer,
-//   ] = await Promise.all([
-//     import('@client/state/configureStore'),
-//     import('@containers/app/RootContainer/RootContainer.web'),
-//   ]);
+// //   const [
+// //     configureStore,
+// //     RootContainer,
+// //   ] = await Promise.all([
+// //     import('@client/state/configureStore'),
+// //     import('@containers/app/RootContainer/RootContainer.web'),
+// //   ]);
 
-//   const store = configureStore.default();
+// //   const store = configureStore.default();
 
-//   const render = (Component) => {
-//     ReactDOM.hydrate(
-//       <AppContainer warnings={false}>
-//         <Provider store={store}>
-//           <BrowserRouter>
-//             <Component/>
-//           </BrowserRouter>
-//         </Provider>
-//       </AppContainer>,
-//       rootEl,
-//     );
-//   };
+// //   const render = (Component) => {
+// //     ReactDOM.hydrate(
+// //       <AppContainer warnings={false}>
+// //         <Provider store={store}>
+// //           <BrowserRouter>
+// //             <Component/>
+// //           </BrowserRouter>
+// //         </Provider>
+// //       </AppContainer>,
+// //       rootEl,
+// //     );
+// //   };
   
-//   render(RootContainer.default);
+// //   render(RootContainer.default);
 
-//   if (module.hot) {
-//     module.hot.accept('./containers/app/RootContainer/RootContainer.web', () => {
-//       Logger.warn('Hot Module Replace');
-//       const component = require('@containers/app/RootContainer/RootContainer.web').default;
-//       render(component);
-//     });
-//   }
-// })();
+// //   if (module.hot) {
+// //     module.hot.accept('./containers/app/RootContainer/RootContainer.web', () => {
+// //       Logger.warn('Hot Module Replace');
+// //       const component = require('@containers/app/RootContainer/RootContainer.web').default;
+// //       render(component);
+// //     });
+// //   }
+// // })();
 
 const store = configureStore({
   initialState: window[appConfig.reduxStateKey],
 });
 
-const app = document.getElementById('app-root');
+const appRoot = document.getElementById('app-root');
 const element = (
   <ReduxProvider store={store}>
     <BrowserRouter>
@@ -71,4 +70,19 @@ const element = (
   </ReduxProvider>
 );
 
-ReactDOM.hydrate(element, app);
+function render(Component) {
+  ReactDOM.hydrate(
+    element,
+    appRoot,
+  );
+}
+
+console.log('client.jsx');
+
+render(element, appRoot);
+
+if (module.hot) {
+  // module.hot.accept('', () => {
+  //   console.log(1);
+  // })
+}

--- a/src/server/server.local.js
+++ b/src/server/server.local.js
@@ -1,0 +1,109 @@
+import express from "express";
+import fs from 'fs';
+import path from "path";
+import { Provider as ReduxProvider } from 'react-redux';
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { StaticRouter } from 'react-router-dom';
+
+import appConfig from '@config/appConfig';
+import configureStore from '../client/state/configureStore';
+import makeHtml from './makeHtml';
+import RootContainer from '@containers/app/RootContainer/RootContainer.web';
+
+const webpackDevMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
+import webpack from 'webpack';
+import webpackConfig from '../../internals/webpack/webpack.config.dev.web';
+const webpackCompiler = webpack(webpackConfig);
+
+const DIST_BUNDLE_PATH = path.resolve(__dirname, '../../dist/bundle');
+
+const PORT = 5001;
+
+const SERVER_STATUS = {
+  LAUNCH_ERROR: 'LAUNCH_ERROR',
+  LAUNCH_SUCCESS: 'LAUNCH_SUCCESS',
+  NOT_LAUNCHED: 'NOT_LAUNCHED',
+};
+
+const app = express();
+const state = {
+  entrypointBundles: [],
+  status: SERVER_STATUS.NOT_LAUNCHED,
+};
+
+(function getBundles(state) {
+  try {
+    const data = fs.readFileSync(`${DIST_BUNDLE_PATH}/build.json`);
+    const build = JSON.parse(data.toString('utf8'));
+    console.info('[webpack build]: %o', build);
+
+    Object.keys(build.entrypoints)
+      .map((entrypoint) => {
+        build.entrypoints[entrypoint].assets.map((asset) => {
+          asset.endsWith('js') && state.entrypointBundles.push(asset);
+        });
+      });
+      state.status = SERVER_STATUS.LAUNCH_SUCCESS;
+  } catch (err) {
+    console.error(err);
+    state.status = SERVER_STATUS.LAUNCH_ERROR;
+  }
+})();
+
+app.use(htmlLogger);
+
+// app.use(express.static(DIST_BUNDLE_PATH));
+
+app.use(webpackDevMiddleware(webpackCompiler, {
+  publicPath: webpackConfig.output.publicPath,
+  stats: {
+    color: true,
+  },
+}));
+
+app.use(webpackHotMiddleware(webpackCompiler, {
+  heartbeat: 2000,
+}));
+
+app.get("/*", (req, res) => {
+  console.log(1)
+  res.send({
+    power: 1,
+  })
+  // const store = configureStore();
+
+  // if (state.status !== SERVER_STATUS.LAUNCH_SUCCESS) {
+  //   res.writeHead(500);
+  //   res.end('server is not launched');
+  // } else {
+  //   const element = (
+  //     <ReduxProvider store={store}>
+  //       <StaticRouter 
+  //         context={{}}
+  //         location={req.url}>
+  //         <RootContainer/>
+  //       </StaticRouter>
+  //     </ReduxProvider>
+  //   );
+  //   const elementInString = renderToString(element);
+
+  //   res.writeHead(200, { "Content-Type": "text/html" });
+  //   res.end(makeHtml({
+  //     reactDom: elementInString,
+  //     reduxState: store,
+  //     reduxStateKey: appConfig.reduxStateKey,
+  //     bundles: state.entrypointBundles,
+  //   }));
+  // }
+});
+
+app.listen(PORT, () => {
+  console.info('Server listening: %s', PORT);
+});
+
+function htmlLogger(req, res, next) {
+  console.info('%s f- url: %s, user agent: %s', new Date(), req.url, req.get('User-Agent'));
+  next();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7353,6 +7353,10 @@ webpack-merge@^4.1.1:
   dependencies:
     lodash "^4.17.5"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "http://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"


### PR DESCRIPTION
- Former plan to use babel + nodemon to watch and relaunch the server
application has been changed to using only webpack. Webpack internally has
this funcitonality `watch` that keeps triggering the event when the code
changes.
- babel plugin `module resolver` is no longer used and the configuration thereof
has been removed.
- server.prod and server.local are created.

Fixes https://github.com/eldeni/react-boilerplate/issues/16