### PR TITLE
refactor: create scripts `build:server:local`, `build:server:prod`

### DIFF
--- a/internals/gulp/gulpfile.js
+++ b/internals/gulp/gulpfile.js
@@ -75,6 +75,28 @@ gulp.task('webpack:client:prod', (done) => {
   });
 });
 
+gulp.task('webpack:server:local', (done) => {
+  const webpackConfig = require('../webpack/webpack.config.server.local');
+  const compiler = webpack(webpackConfig);
+
+  compiler.run((err, stats) => {
+    console.info('[webpack:server:prod] webpack configuration:\n%o\n', webpackConfig);
+    if (err || stats.hasErrors()) {
+      console.error(stats.toString('erros-only'));
+    } else {
+      const info = stats.toJson({
+        all: false,
+        assets: true,
+        builtAt: true,
+        entrypoints: true,
+      });
+      console.info('[webpack:server:prod] compilation success:\n%o\n', info);
+      // fs.writeFileSync(`${DIST_BUNDLE_PATH}/build.json`, JSON.stringify(info));
+    }
+    done();
+  });
+});
+
 gulp.task('webpack:server:prod', (done) => {
   const webpackConfig = require('../webpack/webpack.config.server.prod');
   const compiler = webpack(webpackConfig);
@@ -97,5 +119,6 @@ gulp.task('webpack:server:prod', (done) => {
   });
 });
 
-gulp.task('build:client', gulp.series('clean:client', 'webpack:client:prod'));
-gulp.task('build:server', gulp.series('clean:server', 'webpack:server:prod'));
+gulp.task('build:client:prod', gulp.series('clean:client', 'webpack:client:prod'));
+gulp.task('build:server:prod', gulp.series('clean:server', 'webpack:server:prod'));
+gulp.task('build:server:local', gulp.series('clean:server', 'webpack:server:local'));

--- a/internals/webpack/paths.js
+++ b/internals/webpack/paths.js
@@ -1,5 +1,8 @@
 const path = require('path');
 
 module.exports = {
-  distBundlePath: path.resolve(__dirname, '../../dist/bundle'),
+  distBundle: path.resolve(__dirname, '../../dist/bundle'),
+  distServer: path.resolve(__dirname, '../../dist/server'),
+  srcClient: path.resolve(__dirname, '../../src/client'),
+  srcServer: path.resolve(__dirname, '../../src/server'),
 };

--- a/internals/webpack/webpack.config.client.local.web.js
+++ b/internals/webpack/webpack.config.client.local.web.js
@@ -2,15 +2,15 @@ const path = require('path');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 
-const config  = require('./webpack.config.client.web');
-const CLIENT_PATH = path.resolve(__dirname, '../../src/client');
+const config = require('./webpack.config.client.web');
+const paths = require('./paths');
 
 const devConfig = {
   devtool: 'source-map',
   entry: {
     app: [ 
       'webpack-hot-middleware/client', 
-      path.resolve(CLIENT_PATH, 'client.jsx'),
+      path.resolve(paths.srcClient, 'client.jsx'),
     ],
   },
   mode: 'development',

--- a/internals/webpack/webpack.config.client.prod.web.js
+++ b/internals/webpack/webpack.config.client.prod.web.js
@@ -3,7 +3,6 @@ const path = require('path');
 const webpack = require('webpack');
 
 const config  = require('./webpack.config.client.web');
-const APP_PATH = path.resolve(__dirname, '../../src/app');
 
 const prodConfig = {
   mode: 'production',

--- a/internals/webpack/webpack.config.client.web.js
+++ b/internals/webpack/webpack.config.client.web.js
@@ -2,15 +2,12 @@ const htmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 const babelRc = require('../babel/.babelrc');
-
-const CLIENT_PATH = path.resolve(__dirname, '../../src/client');
-const DIST_BUNDLE_PATH = path.resolve(__dirname, '../../dist/bundle');
-const INDEX_PATH = path.resolve(__dirname, './static/index.html');
+const paths = require('./paths');
 
 module.exports = {
   context: __dirname,
   entry: {
-    app: path.resolve(CLIENT_PATH, 'client.jsx'),
+    app: path.resolve(paths.srcClient, 'client.jsx'),
     react: [ 'react', 'react-dom', 'redux', 'react-redux' ],
   },
   externals: {},
@@ -58,7 +55,7 @@ module.exports = {
     }
   },
   output: {
-    path: DIST_BUNDLE_PATH,
+    path: paths.distBundle,
     filename: '[name].[chunkhash].js',
     chunkFilename: 'chunk.[chunkhash].js',
     publicPath: '/',
@@ -75,19 +72,19 @@ module.exports = {
     ],
     extensions: ['.js', '.jsx'],
     alias: {
-      '@actions': path.resolve(CLIENT_PATH, 'state', 'actions'),
-      '@apis': path.resolve(CLIENT_PATH, 'apis'),
-      '@app-assets': path.resolve(CLIENT_PATH, 'app-assets'),
-      '@components': path.resolve(CLIENT_PATH, 'components'),
-      '@config': path.resolve(CLIENT_PATH, 'config'),
-      '@constants': path.resolve(CLIENT_PATH, 'constants'),
-      '@containers': path.resolve(CLIENT_PATH, 'containers'),
-      '@hocs': path.resolve(CLIENT_PATH, 'hocs'),
-      '@models': path.resolve(CLIENT_PATH, 'models'),
-      '@modules': path.resolve(CLIENT_PATH, 'modules'),
-      '@selectors': path.resolve(CLIENT_PATH, 'state', 'selectors'),
-      '@client': path.resolve(CLIENT_PATH),
-      '@utils': path.resolve(CLIENT_PATH, 'utils'),
+      '@actions': path.resolve(paths.srcClient, 'state', 'actions'),
+      '@apis': path.resolve(paths.srcClient, 'apis'),
+      '@app-assets': path.resolve(paths.srcClient, 'app-assets'),
+      '@components': path.resolve(paths.srcClient, 'components'),
+      '@config': path.resolve(paths.srcClient, 'config'),
+      '@constants': path.resolve(paths.srcClient, 'constants'),
+      '@containers': path.resolve(paths.srcClient, 'containers'),
+      '@hocs': path.resolve(paths.srcClient, 'hocs'),
+      '@models': path.resolve(paths.srcClient, 'models'),
+      '@modules': path.resolve(paths.srcClient, 'modules'),
+      '@selectors': path.resolve(paths.srcClient, 'state', 'selectors'),
+      '@client': path.resolve(paths.srcClient),
+      '@utils': path.resolve(paths.srcClient, 'utils'),
     },
   },
   target: 'web',

--- a/internals/webpack/webpack.config.server.base.js
+++ b/internals/webpack/webpack.config.server.base.js
@@ -1,0 +1,29 @@
+const serverProdConfig = {
+  devtool: 'source-map',
+  entry: {
+    server: [
+      path.resolve(SERVER_PATH, 'server.local.js'),
+    ],
+  },
+  externals: [
+    nodeExternals({
+      whitelist: /\.css$/,
+    }),
+  ],
+  mode: 'development',
+  node: {
+    __dirname: false,
+  },
+  optimization: {
+    minimize: false,
+  },
+  output: {
+    path: DIST_SERVER_PATH,
+    filename: '[name].[hash].js',
+    publicPath: '/',
+  },
+  stats: {
+    colors: true,
+  },
+  target: 'node',
+};

--- a/internals/webpack/webpack.config.server.local.js
+++ b/internals/webpack/webpack.config.server.local.js
@@ -9,7 +9,7 @@ const serverProdConfig = {
   devtool: 'source-map',
   entry: {
     server: [
-      path.join(paths.srcServer, 'server.prod.js'),
+      path.join(paths.srcServer, 'server.local.js'),
     ],
   },
   externals: [
@@ -17,7 +17,7 @@ const serverProdConfig = {
       whitelist: /\.css$/,
     }),
   ],
-  mode: 'production',
+  mode: 'development',
   node: {
     __dirname: false,
   },
@@ -26,7 +26,7 @@ const serverProdConfig = {
   },
   output: {
     path: paths.distServer,
-    filename: 'server.prod.js',
+    filename: 'server.local.js',
     publicPath: '/',
   },
   stats: {

--- a/package.json
+++ b/package.json
@@ -62,11 +62,13 @@
   "main": "",
   "name": "react-boilerplate",
   "scripts": {
-    "build:server": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server",
-    "build:client": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:client",
+    "build:client:prod": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:client:prod",
+    "build:prod": "npm-run-all --parallel build:client:prod build:server:prod",
+    "build:server:local": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server:local",
+    "build:server:prod": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server:prod",
+    "dev:local": "NODE_ENV=development yarn run build:server:local && node ./dist/server/server.local.js",
     "lint": "./node_modules/.bin/eslint ./src",
-    "start:local": "NODE_ENV=development npm-run-all --parallel build:server build:client && node ./dist/server/server.js",
-    "start:prod": "NODE_ENV=production npm-run-all --parallel build:server build:client && node ./dist/server/server.prod.js",
+    "start:prod": "NODE_ENV=production node ./dist/server/server.prod.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "version": "0.0.1"

--- a/src/server/createServer.js
+++ b/src/server/createServer.js
@@ -1,0 +1,3 @@
+module.exports = function createServer() {
+  
+};

--- a/src/server/server.local.js
+++ b/src/server/server.local.js
@@ -5,19 +5,19 @@ import { Provider as ReduxProvider } from 'react-redux';
 import React from "react";
 import { renderToString } from "react-dom/server";
 import { StaticRouter } from 'react-router-dom';
+import webpack from 'webpack';
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import webpackHotMiddleware from 'webpack-hot-middleware';
 
 import appConfig from '@config/appConfig';
 import configureStore from '../client/state/configureStore';
 import makeHtml from './makeHtml';
 import RootContainer from '@containers/app/RootContainer/RootContainer.web';
+import webpackConfig from '../../internals/webpack/webpack.config.client.local.web';
 
-const webpackDevMiddleware = require('webpack-dev-middleware');
-const webpackHotMiddleware = require('webpack-hot-middleware');
-import webpack from 'webpack';
-import webpackConfig from '../../internals/webpack/webpack.config.dev.web';
+console.log(123, webpackConfig);
+
 const webpackCompiler = webpack(webpackConfig);
-
-const DIST_BUNDLE_PATH = path.resolve(__dirname, '../../dist/bundle');
 
 const PORT = 5001;
 
@@ -33,28 +33,7 @@ const state = {
   status: SERVER_STATUS.NOT_LAUNCHED,
 };
 
-(function getBundles(state) {
-  try {
-    const data = fs.readFileSync(`${DIST_BUNDLE_PATH}/build.json`);
-    const build = JSON.parse(data.toString('utf8'));
-    console.info('[webpack build]: %o', build);
-
-    Object.keys(build.entrypoints)
-      .map((entrypoint) => {
-        build.entrypoints[entrypoint].assets.map((asset) => {
-          asset.endsWith('js') && state.entrypointBundles.push(asset);
-        });
-      });
-      state.status = SERVER_STATUS.LAUNCH_SUCCESS;
-  } catch (err) {
-    console.error(err);
-    state.status = SERVER_STATUS.LAUNCH_ERROR;
-  }
-})();
-
 app.use(htmlLogger);
-
-// app.use(express.static(DIST_BUNDLE_PATH));
 
 app.use(webpackDevMiddleware(webpackCompiler, {
   publicPath: webpackConfig.output.publicPath,


### PR DESCRIPTION
- Scripts such as `build:server:prod`, `build:server:local` and more  are
defined. This is to separate the local and production build procedure.
- `__dirname` of webpack configuration is set to be false for when path
resolves the absolute path of the file.
- server is revamped with its state not has `clone()` method to mutate.
- paths are configured in a single file `paths.js`.