### PR TITLE
fix: correct hmr by not bundling server side app

### DIFF
--- a/internals/babel/.babelrc.js
+++ b/internals/babel/.babelrc.js
@@ -1,17 +1,46 @@
 module.exports = {
   "env": {
-    "local": {
+    "development": {
       "plugins": [
         "react-hot-loader/babel",
-        [ "babel-plugin-styled-components", {
-          "displayName": false
-        }]
+        [ 
+          "babel-plugin-styled-components", 
+          {
+            "displayName": true,
+            "ssr": true,
+          }
+        ]
       ]
     }
   },
+  "plugins": [
+    [
+      "module-resolver", {
+        "alias": {
+          "@actions": "./src/client/state/actions",
+          "@apis": "./src/client/apis",
+          "@app-assets": "./src/client/app-assets",
+          "@client": "./src/client",
+          "@components": "./src/client/components",
+          "@config": "./src/client/config",
+          "@constants": "./src/client/constants",
+          "@containers": "./src/client/containers",
+          "@hocs": "./src/client/hocs",
+          "@models": "./src/client/models",
+          "@modules": "./src/client/modules",
+          "@selectors": "./src/client/state/selectors",
+          "@utils": "./src/client/utils",
+        },
+      }
+    ]
+  ],
   "presets": [
     "@babel/preset-env",
     "@babel/preset-react",
-    ["@babel/preset-stage-2", { "decoratorsLegacy": true }]
+    [ 
+      "@babel/preset-stage-2", { 
+        "decoratorsLegacy": true 
+      }
+    ],
   ],
 };

--- a/internals/webpack/webpack.config.client.local.web.js
+++ b/internals/webpack/webpack.config.client.local.web.js
@@ -1,11 +1,10 @@
 const path = require('path');
 const webpack = require('webpack');
-const merge = require('webpack-merge');
 
-const config = require('./webpack.config.client.web');
 const paths = require('../../src/server/paths');
+const webpackConfigClientWeb = require('./webpack.config.client.web');
 
-const devConfig = {
+const config = {
   devtool: 'source-map',
   entry: {
     app: [ 
@@ -26,4 +25,4 @@ const devConfig = {
   ],
 };
 
-module.exports = merge(config, devConfig);
+module.exports = Object.assign({}, webpackConfigClientWeb, config);

--- a/internals/webpack/webpack.config.client.prod.web.js
+++ b/internals/webpack/webpack.config.client.prod.web.js
@@ -1,11 +1,10 @@
-const merge = require('webpack-merge');
 const path = require('path');
 const webpack = require('webpack');
 
-const config  = require('./webpack.config.client.web');
+const webpackConfigClientWeb  = require('./webpack.config.client.web');
 
-const prodConfig = {
-  mode: 'development', // temp
+const config = {
+  mode: 'production',
 };
 
-module.exports = merge(config, prodConfig);
+module.exports = Object.assign({}, webpackConfigClientWeb, config);

--- a/internals/webpack/webpack.config.client.web.js
+++ b/internals/webpack/webpack.config.client.web.js
@@ -1,4 +1,3 @@
-const htmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 const babelRc = require('../babel/.babelrc');
@@ -61,31 +60,12 @@ module.exports = {
     publicPath: '/',
   },
   plugins: [
-    // new htmlWebpackPlugin({
-    //   filename: 'raw_index.html',
-    //   template: INDEX_PATH,
-    // }),
   ],
   resolve: {
     modules: [
       'node_modules',
     ],
     extensions: ['.js', '.jsx'],
-    alias: {
-      '@actions': path.resolve(paths.srcClient, 'state', 'actions'),
-      '@apis': path.resolve(paths.srcClient, 'apis'),
-      '@app-assets': path.resolve(paths.srcClient, 'app-assets'),
-      '@components': path.resolve(paths.srcClient, 'components'),
-      '@config': path.resolve(paths.srcClient, 'config'),
-      '@constants': path.resolve(paths.srcClient, 'constants'),
-      '@containers': path.resolve(paths.srcClient, 'containers'),
-      '@hocs': path.resolve(paths.srcClient, 'hocs'),
-      '@models': path.resolve(paths.srcClient, 'models'),
-      '@modules': path.resolve(paths.srcClient, 'modules'),
-      '@selectors': path.resolve(paths.srcClient, 'state', 'selectors'),
-      '@client': path.resolve(paths.srcClient),
-      '@utils': path.resolve(paths.srcClient, 'utils'),
-    },
   },
   target: 'web',
 };

--- a/internals/webpack/webpack.config.server.local.js
+++ b/internals/webpack/webpack.config.server.local.js
@@ -1,22 +1,18 @@
-const merge = require('webpack-merge');
 const nodeExternals = require('webpack-node-externals');
 const path = require('path');
 
-const clientConfig = require('./webpack.config.client.web');
 const paths = require('../../src/server/paths');
+const webpackConfigClientWeb = require('./webpack.config.client.web');
 
-const serverProdConfig = {
+const config = {
   devtool: 'source-map',
   entry: {
-    server: [
-      path.join(paths.srcServer, 'server.local.js'),
-    ],
     rootContainer: path.join(paths.srcClient, 'containers/app/RootContainer/RootContainer.web.jsx'),
   },
   externals: [
     nodeExternals({
       whitelist: /\.css$/,
-    }), 
+    }),
   ],
   mode: 'development',
   node: {
@@ -27,7 +23,7 @@ const serverProdConfig = {
   },
   output: {
     path: paths.distServer,
-    filename: 'server.local.[name].[hash].js',
+    filename: 'server.local.[name].js',
     library: '',
     libraryTarget: 'commonjs',
     publicPath: '/',
@@ -38,4 +34,4 @@ const serverProdConfig = {
   target: 'node',
 };
 
-module.exports = Object.assign(clientConfig, serverProdConfig);
+module.exports = Object.assign({}, webpackConfigClientWeb, config);

--- a/internals/webpack/webpack.config.server.prod.js
+++ b/internals/webpack/webpack.config.server.prod.js
@@ -1,11 +1,10 @@
-const merge = require('webpack-merge');
 const nodeExternals = require('webpack-node-externals');
 const path = require('path');
 
-const clientConfig = require('./webpack.config.client.web');
 const paths = require('../../src/server/paths');
+const webpackConfigClientWeb = require('./webpack.config.client.web');
 
-const serverProdConfig = {
+const config = {
   devtool: 'source-map',
   entry: {
     server: [
@@ -17,7 +16,7 @@ const serverProdConfig = {
       whitelist: /\.css$/,
     }),
   ],
-  mode: 'development', // temp
+  mode: 'development',
   node: {
     __dirname: false,
   },
@@ -37,4 +36,4 @@ const serverProdConfig = {
   target: 'node',
 };
 
-module.exports = Object.assign(clientConfig, serverProdConfig);
+module.exports = Object.assign({}, webpackConfigClientWeb, config);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "webpack": "^4.1.1",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-hot-middleware": "^2.21.2",
-    "webpack-merge": "^4.1.1",
     "webpack-node-externals": "^1.7.2"
   },
   "license": "MIT",
@@ -63,12 +62,11 @@
   "name": "react-boilerplate",
   "scripts": {
     "build:client:prod": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:client:prod",
-    "build:prod": "npm-run-all --parallel build:client:prod build:server:prod",
-    "build:server:local": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server:local",
-    "build:server:prod": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server:prod",
-    "dev:local": "NODE_ENV=development node ./src/server/server.js",
+    "build:prod": "NODE_ENV=production npm-run-all --parallel build:client:prod build:server",
+    "build:server": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server",
+    "dev:local": "yarn run build:server && NODE_ENV=development node ./dist/babel/server/server.js",
     "lint": "./node_modules/.bin/eslint ./src",
-    "start:prod": "NODE_ENV=production node ./src/server/server.js",
+    "start:prod": "NODE_ENV=production node ./dist/babel/server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "version": "0.0.1"

--- a/src/client/client.jsx
+++ b/src/client/client.jsx
@@ -1,5 +1,5 @@
-// import { AppContainer } from 'react-hot-loader';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { hot } from 'react-hot-loader';
 import { Provider as ReduxProvider } from 'react-redux';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -10,8 +10,7 @@ import RootContainer from '@containers/app/RootContainer/RootContainer.web';
 
 // import Logger from '@modules/Logger';
 
-// Logger.info(`App is running on env: ${process.env.NODE_ENV}`);
-console.log('client.jsx in env: %s', process.env.NODE_ENV);
+console.info('App (client.jsx) is running, NODE_ENV: %s', process.env.NODE_ENV);
 
 const appRoot = document.getElementById('app-root');
 
@@ -27,23 +26,11 @@ const store = configureStore({
   initialState: window[appConfig.reduxStateKey],
 });
 
-function render(Component) {
-  ReactDOM.hydrate(
-    <ReduxProvider store={store}>
-      <BrowserRouter>
-        <Component/>
-      </BrowserRouter>
-    </ReduxProvider>,
-    appRoot,
-  );
-}
-
-render(RootContainer);
-
-if (module.hot) {
-  module.hot.accept('./containers/app/RootContainer/RootContainer.web', () => {
-    console.warn('Hot module replace');
-    const component = require('./containers/app/RootContainer/RootContainer.web').default;
-    render(component);
-  })
-}
+ReactDOM.hydrate(
+  <ReduxProvider store={store}>
+    <BrowserRouter>
+      <RootContainer/>
+    </BrowserRouter>
+  </ReduxProvider>,
+  appRoot,
+);

--- a/src/client/containers/app/RootContainer/RootContainer.web.jsx
+++ b/src/client/containers/app/RootContainer/RootContainer.web.jsx
@@ -1,5 +1,6 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { withRouter } from "react-router-dom";
@@ -57,6 +58,7 @@ const makeMapStateToProps = () => {
 };
 
 export default compose(
+  hot(module),
   withRouter,
   connect(makeMapStateToProps),
 )(RootContainer);

--- a/src/client/state/configureStore.js
+++ b/src/client/state/configureStore.js
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware, Store } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
 import reducers from './reducers/reducers';
@@ -30,4 +30,4 @@ export default function configureStore({
   }
 
   return store;
-}
+};

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -17,12 +17,16 @@ Did you call process.chdir() properly?`);
 })();
 
 module.exports = {
+  dist: DIST_PATH,
+  distBabel: path.resolve(DIST_PATH, 'babel'),
   distBundle: path.resolve(DIST_PATH, 'bundle'),
   distServer: path.resolve(DIST_PATH, 'server'),
+  logs: path.resolve(ROOT_PATH, 'logs'),
+  src: SRC_PATH,
   srcClient: path.resolve(SRC_PATH, 'client'),
   srcServer: path.resolve(SRC_PATH, 'server'),
-  webpackClientLocalWeb: path.resolve(WEBPACK_PATH, 'webpack.config.client.local.web'),
-  webpackClientProdWeb: path.resolve(WEBPACK_PATH, 'webpack.config.client.prod.web'),
-  webpackServerLocal: path.resolve(WEBPACK_PATH, 'webpack.config.server.local'),
-  webpackServerProd: path.resolve(WEBPACK_PATH, 'webpack.config.server.prod'),
+  webpackConfigClientLocalWeb: path.resolve(WEBPACK_PATH, 'webpack.config.client.local.web.js'),
+  webpackConfigClientProdWeb: path.resolve(WEBPACK_PATH, 'webpack.config.client.prod.web'),
+  webpackConfigServerLocal: path.resolve(WEBPACK_PATH, 'webpack.config.server.local'),
+  webpackConfigServerProd: path.resolve(WEBPACK_PATH, 'webpack.config.server.prod'),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7425,12 +7425,6 @@ webpack-log@^1.0.1:
     loglevelnext "^1.0.1"
     uuid "^3.1.0"
 
-webpack-merge@^4.1.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.3.tgz#8aaff2108a19c29849bc9ad2a7fd7fce68e87c4a"
-  dependencies:
-    lodash "^4.17.5"
-
 webpack-node-externals@^1.7.2:
   version "1.7.2"
   resolved "http://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"


### PR DESCRIPTION
- Server side application is not bundled. It is only transpiled by Babel. A main
reason for this is that when bundled, the application needs to know the required
modules at compile time. Though this could be configured with `externals` option
of webpack, clearing require.cache does not work as easily as expected.
Therefore, we determined to make server side app only transpiled with Babel,
and not bundled with Webpack.
- Module aliases configuration is moved to .babelrc.js. Module resolution is
done with `module-resolver`.`
- `webpack-merge` is removed from dependency.

Fixes https://github.com/eldeni/react-boilerplate/issues/24