### PR TITLE
refactor: create module alias `@server/` and directory `serverApp/`

### DIFF
--- a/internals/babel/.babelrc.js
+++ b/internals/babel/.babelrc.js
@@ -29,6 +29,7 @@ module.exports = {
           "@models": "./src/client/models",
           "@modules": "./src/client/modules",
           "@selectors": "./src/client/state/selectors",
+          "@server": "./src/server",
           "@utils": "./src/client/utils",
         },
       }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -5,9 +5,10 @@ const http = require('http');
 const path = require('path');
 const webpack = require('webpack');
 
-const LaunchStatus = require('./constants/LaunchStatus');
-const paths = require('./paths');
+const LaunchStatus = require('@server/constants/LaunchStatus');
+const paths = require('@server/paths');
 const webpackConfigServerLocal = require(paths.webpackConfigServerLocal);
+const serverUtils = require('@server/serverApp/serverUtils');
 
 const prodEnv = process.env.NODE_ENV === 'production' || false;
 let httpServer = undefined;
@@ -27,7 +28,7 @@ function launchLocalServer() {
     poll: undefined,
   };
 
-  const server = require('./server.local').default;
+  const server = require('@server/serverApp/server.local').default;
   const state = server.state;
   state.update({
     localServer: true,
@@ -48,7 +49,7 @@ function launchLocalServer() {
       console.info('[webpack:server:local] webpack watch() success: at: %s, \n%o\n', new Date(), info);
       
       delete require.cache[state.rootContainerPath];
-      printRequireCache();
+      serverUtils.printRequireCache();
       
       const rootContainerBundlePath = path.resolve(paths.distServer, info.entrypoints.rootContainer.assets[0]);
       state.update({
@@ -60,7 +61,7 @@ function launchLocalServer() {
 }
 
 function launchProdServer() {
-  const server = require('./server.prod').default;
+  const server = require('@server/serverApp/server.prod').default;
   runHttpServer(server.app);
 }
 
@@ -76,8 +77,9 @@ function runHttpServer(app) {
 }
 
 function printRequireCache() {
-  return Object.keys(require.cache)
+  const keys = Object.keys(require.cache)
     .filter((key) => {
-      return !key.startsWith('/Users/mistock1706/work/Eldeni/react-boilerplate/node_modules/');
+      return !key.includes('/node_modules/');
     });
+  console.info("require.cache: ", keys);
 }

--- a/src/server/serverApp/createExpress.js
+++ b/src/server/serverApp/createExpress.js
@@ -2,9 +2,9 @@ import express from "express";
 import util from 'util';
 
 // import appConfig from '@config/appConfig';
-import configureStore from '../client/state/configureStore';
-import LaunchStatus from './constants/LaunchStatus';
-import makeHtml from './makeHtml';
+import configureStore from '@client/state/configureStore';
+import LaunchStatus from '@server/constants/LaunchStatus';
+import makeHtml from '@server/serverApp/makeHtml';
 
 export default function createServer({
   enhance = (app, state) => {},

--- a/src/server/serverApp/makeHtml.jsx
+++ b/src/server/serverApp/makeHtml.jsx
@@ -4,8 +4,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { renderToString } from "react-dom/server";
 import { StaticRouter } from 'react-router-dom';
 
-import RootContainer from '@containers/app/RootContainer/RootContainer.web';
-
 const App = ({
   localServer,
   requestUrl,

--- a/src/server/serverApp/server.local.js
+++ b/src/server/serverApp/server.local.js
@@ -5,10 +5,10 @@ import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 
-import { calculateNextStateWhileSearchingForBundles } from './serverUtils';
-import createExpress from './createExpress';
-import LaunchStatus from './constants/LaunchStatus';
-import paths from './paths';
+import { calculateNextStateWhileSearchingForBundles } from '@server/serverApp/serverUtils';
+import createExpress from '@server/serverApp/createExpress';
+import LaunchStatus from '@server/constants/LaunchStatus';
+import paths from '@server/paths';
 
 const webpackConfigClientLocalWeb = require(paths.webpackConfigClientLocalWeb)
 

--- a/src/server/serverApp/server.prod.js
+++ b/src/server/serverApp/server.prod.js
@@ -6,10 +6,10 @@ import React from "react";
 import { renderToString } from "react-dom/server";
 import { StaticRouter } from 'react-router-dom';
 
-import { calculateNextStateWhileSearchingForBundles } from './serverUtils';
-import createExpress from './createExpress';
-import LaunchStatus from './constants/LaunchStatus';
-import paths from './paths';
+import { calculateNextStateWhileSearchingForBundles } from '@server/serverApp/serverUtils';
+import createExpress from '@server/serverApp/createExpress';
+import LaunchStatus from '@server/constants/LaunchStatus';
+import paths from '@server/paths';
 
 export default createExpress({
   enhance: (app, state) => {

--- a/src/server/serverApp/serverUtils.js
+++ b/src/server/serverApp/serverUtils.js
@@ -1,4 +1,4 @@
-const LaunchStatus = require('./constants/LaunchStatus');
+const LaunchStatus = require('@server/constants/LaunchStatus');
 
 exports.calculateNextStateWhileSearchingForBundles = function (entrypoints) {
   try {
@@ -20,4 +20,12 @@ exports.calculateNextStateWhileSearchingForBundles = function (entrypoints) {
       launchStatus: LaunchStatus.ERROR_BUNDLE_NOT_FOUND,
     };
   }
+};
+
+exports.printRequireCache = function () {
+  const keys = Object.keys(require.cache)
+    .filter((key) => {
+      return !key.includes('/node_modules/');
+    });
+  console.info("require.cache: ", keys);
 };


### PR DESCRIPTION
- `serverApp/` contains serverApplication files except server.js, which is an
entrypoint.
- printRequireCache() is moved to serverUtils.
- module alias `@server/` is defined.

Fixes https://github.com/eldeni/react-boilerplate/issues/35