### PR TITLE
chore: define gulp parallel task `build:prod` and remove a script

### DIFF
--- a/internals/gulp/gulpfile.js
+++ b/internals/gulp/gulpfile.js
@@ -79,7 +79,13 @@ gulp.task(Task.WEBPACK_CLIENT_PROD, (done) => {
   const compiler = webpack(webpackConfig);
 
   compiler.run((err, stats) => {
-    buildLog(Task.WEBPACK_CLIENT_PROD, 'webpack configuration:\n%o\n', webpackConfig);
+    buildLog(
+      Task.WEBPACK_CLIENT_PROD,
+      'NODE_ENV: %s, webpack configuration: %o',
+      process.env.NODE_ENV,
+      webpackConfig,
+    );
+
     if (err || stats.hasErrors()) {
       const errorMsg = stats.toString('errors-only');
       buildLog(Task.WEBPACK_CLIENT_PROD, 'error', errorMsg);
@@ -100,3 +106,4 @@ gulp.task(Task.WEBPACK_CLIENT_PROD, (done) => {
 
 gulp.task('build:client:prod', gulp.series('clean:bundle', 'webpack:client:prod'));
 gulp.task('build:server', gulp.series('clean:babel', 'babel'));
+gulp.task('build:prod', gulp.parallel('build:client:prod', 'build:server'));

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   "main": "",
   "name": "react-boilerplate",
   "scripts": {
-    "build:client:prod": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:client:prod",
-    "build:prod": "NODE_ENV=production npm-run-all --parallel build:client:prod build:server",
+    "build:prod": "NODE_ENV=production ./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:prod",
     "build:server": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server",
     "dev:local": "NODE_ENV=development yarn run build:server && NODE_ENV=development node ./dist/babel/server/server.js",
     "lint": "./node_modules/.bin/eslint ./src",


### PR DESCRIPTION
- Script `build:client:prod` is removed.

Fixes https://github.com/eldeni/react-boilerplate/issues/23