### PR TITLE
feat: define gulp task `copy:public` that copies static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,3 @@ __temp/
 .vscode/
 build/
 dist/
-tsconfig.json

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -26,6 +26,7 @@ module.exports = {
   src: SRC_PATH,
   srcClient: path.resolve(SRC_PATH, 'client'),
   srcServer: path.resolve(SRC_PATH, 'server'),
+  srcServerPublic: path.resolve(SRC_PATH, 'server/public'),
   srcUniversal: path.resolve(SRC_PATH, 'universal'),
   webpackConfigClientLocalWeb: path.resolve(WEBPACK_PATH, 'webpack.config.client.local.web.js'),
   webpackConfigClientProdWeb: path.resolve(WEBPACK_PATH, 'webpack.config.client.prod.web'),

--- a/src/universal/components/app/Root/Root.web.tsx
+++ b/src/universal/components/app/Root/Root.web.tsx
@@ -49,6 +49,10 @@ const Root: React.SFC<RootProps> = ({
         <p>{number}</p>
       </InitialState>
       <div>
+        <p>static file</p>
+        <p><img src="/favicon-256.png" alt=""/></p>
+      </div>
+      <div>
         count
         <Count>
           {count}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": ".",
+    "jsx": "react",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noImplicitAny": false,
+    "paths": {
+      "@actions/*": [
+        "src/universal/state/actions/*"
+      ],
+      "@apis/*": [
+        "src/universal/apis/*"
+      ],
+      "@components/*": [
+        "src/universal/components/*"
+      ],
+      "@client/*": [
+        "src/universal/*"
+      ],
+      "@config/*": [
+        "src/universal/config/*"
+      ],
+      "@constants/*": [
+        "src/universal/constants/*"
+      ],
+      "@containers/*": [
+        "src/universal/containers/*"
+      ],
+      "@hocs/*": [
+        "src/universal/hocs/*"
+      ],
+      "@models/*": [
+        "src/universal/models/*"
+      ],
+      "@modules/*": [
+        "src/universal/modules/*"
+      ],
+      "@selectors/*": [
+        "src/universal/state/selectors/*"
+      ],
+      "@server/*": [
+        "src/server/*"
+      ],
+      "@universal/*": [
+        "src/universal/*"
+      ],
+      "@utils/*": [
+        "src/universal/utils/*"
+      ]
+    },
+    "target": "es6"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
- static files residing in `server/public` are copied via gulp task `copy:public`.
- tsconfig.json is now being tracked.
- Former gulp tasks `clean:babel`, `clean:bundle` are modified or deleted.

Fixes https://github.com/eldeni/react-boilerplate/issues/45