### PR TITLE
fix: make prod server resolve RootContainer correctly.

### DIFF
--- a/internals/webpack/webpack.config.client.prod.web.js
+++ b/internals/webpack/webpack.config.client.prod.web.js
@@ -1,10 +1,28 @@
 const path = require('path');
 const webpack = require('webpack');
 
+const paths = require('../../src/server/paths');
 const webpackConfigClientWeb  = require('./webpack.config.client.web');
 
 const config = {
+  entry: {
+    app: path.resolve(paths.srcClient, 'client.tsx'),
+    react: [ 'react', 'react-dom', 'redux', 'react-redux' ],
+  },
   mode: 'production',
+  optimization: {
+    minimize: true,
+    runtimeChunk: false,
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+  output: {
+    path: paths.distPublicBundle,
+    filename: '[name].[chunkhash].js',
+    chunkFilename: 'chunk.[chunkhash].js',
+    publicPath: '/bundle/',
+  },
 };
 
 module.exports = Object.assign({}, webpackConfigClientWeb, config);

--- a/internals/webpack/webpack.config.client.web.js
+++ b/internals/webpack/webpack.config.client.web.js
@@ -5,10 +5,6 @@ const paths = require('../../src/server/paths');
 
 module.exports = {
   context: __dirname,
-  entry: {
-    app: path.resolve(paths.srcClient, 'client.tsx'),
-    react: [ 'react', 'react-dom', 'redux', 'react-redux' ],
-  },
   externals: {},
   module: {
     rules: [
@@ -45,20 +41,6 @@ module.exports = {
         ],
       },
     ],
-  },
-  mode: 'production',
-  optimization: {
-    minimize: true,
-    runtimeChunk: false,
-    splitChunks: {
-      chunks: 'all',
-    }
-  },
-  output: {
-    path: paths.distPublicBundle,
-    filename: '[name].[chunkhash].js',
-    chunkFilename: 'chunk.[chunkhash].js',
-    publicPath: '/',
   },
   plugins: [
   ],

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -73,8 +73,11 @@ function launchLocalServer() {
 }
 
 function launchProdServer() {
-  const server = require('@server/serverApp/server.prod').default;
-  runHttpServer(server.app);
+  const { app, state } = require('@server/serverApp/server.prod').default;
+  state.update({
+    rootContainerBundlePath: '@containers/app/RootContainer/RootContainer.web',
+  });
+  runHttpServer(app);
 }
 
 function runHttpServer(app) {

--- a/src/server/serverApp/ServerApp.web.tsx
+++ b/src/server/serverApp/ServerApp.web.tsx
@@ -5,20 +5,20 @@ import { StaticRouter } from 'react-router-dom';
 import { Store } from 'redux';
 
 import Log from '@server/modules/Log';
+import RootContainerFallback from '@containers/app/RootContainer/RootContainer.web';
 
 const ServerApp: React.SFC<ServerAppProps> = ({
-  localServer,
   requestUrl,
-  rootContainerPath = '',
+  rootContainerPath,
   store,
 }) => {
   Log.info('<App/> with rootContainerPath: %s', rootContainerPath);
 
   let RootContainerComponent;
   try {
-    RootContainerComponent = localServer
+    RootContainerComponent = rootContainerPath
       ? require(rootContainerPath).default
-      : require('@containers/app/RootContainer/RootContainer.web').default;
+      : RootContainerFallback;
   } catch (err) {
     Log.error('<App/> cannot find rootContainer at: %s', rootContainerPath, err);
     return <div>RootContainer not found</div>;
@@ -37,7 +37,6 @@ const ServerApp: React.SFC<ServerAppProps> = ({
 };
 
 interface ServerAppProps {
-  localServer: boolean,
   requestUrl: string,
   rootContainerPath: string,
   store,

--- a/src/server/serverApp/makeHtml.tsx
+++ b/src/server/serverApp/makeHtml.tsx
@@ -12,7 +12,6 @@ import ServerApp from './ServerApp.web';
 
 const makeHtml: MakeHtml = async function ({
   entrypointBundles,
-  localServer = false,
   requestUrl = '',
   rootContainerPath = '',
   storeKey = 'REDUX_STATE_KEY__NOT_DEFINED',
@@ -25,13 +24,13 @@ const makeHtml: MakeHtml = async function ({
 
   const appRoot = (
     <ServerApp
-      localServer={localServer}
       requestUrl={requestUrl}
       rootContainerPath={rootContainerPath}
       store={store}
     />
   );
   const appRootInString = renderToString(appRoot);
+  expressLog.debug('appRootInString: %s', appRootInString);
 
   return `
 <!DOCTYPE html>


### PR DESCRIPTION
- RootContainerFallComponent is initially loaded and used in production.
- webpack configurations are revamped to delete duplicate props.

Fixes https://github.com/eldeni/react-elden-boilerplate/issues/54