### PR TITLE
feat: setup simple router in RootContainer

### DIFF
--- a/src/universal/components/app/Main/Main.web.tsx
+++ b/src/universal/components/app/Main/Main.web.tsx
@@ -1,0 +1,56 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import styled from 'styled-components';
+
+const StyledMain = styled.div`
+`;
+
+const InitialState = styled.div`
+`;
+
+const Count = styled.p`
+  background-color: black;
+  color: white;
+`;
+
+const Main: React.SFC<MainProps> = ({
+  count,
+  handleClickAdd,
+  number,
+}) => {
+  return (
+    <StyledMain>
+      <InitialState>
+        <p>Initial State</p>
+        <p>{number}</p>
+      </InitialState>
+      <div>
+        <p>static file</p>
+        <p><img src="/favicon-256.png" alt=""/></p>
+      </div>
+      <div>
+        count
+        <Count>
+          {count}
+        </Count>
+        <button onClick={(e) => handleClickAdd(e, {})}>
+          add
+        </button>
+      </div>
+    </StyledMain>
+  );
+};
+
+Main.defaultProps = {
+  count: 0,
+};
+
+interface MainProps {
+  count: number,
+  handleClickAdd: (e: React.SyntheticEvent, data: object) => void,
+  number: number,
+}
+
+export default Main;

--- a/src/universal/components/app/Root/Root.web.tsx
+++ b/src/universal/components/app/Root/Root.web.tsx
@@ -2,7 +2,11 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
+import { Route, Switch } from 'react-router';
 import styled from 'styled-components';
+
+import Main from '@components/app/Main/Main.web';
+import rootRoutes, { RouteEntry } from './rootRotues';
 
 const StyledRoot = styled.div`
   color: blue;
@@ -11,14 +15,6 @@ const StyledRoot = styled.div`
     border-bottom: 1px solid green;
     padding: 15px;
   }
-`;
-
-const InitialState = styled.div`
-`;
-
-const Count = styled.p`
-  background-color: black;
-  color: white;
 `;
 
 const NavBar = styled.div`
@@ -31,10 +27,7 @@ const Location = styled.span`
 `;
 
 const Root: React.SFC<RootProps> = ({
-  count,
-  handleClickAdd,
   handleClickNavigate,
-  number,
   pathname,
 }) => {
   return (
@@ -43,38 +36,33 @@ const Root: React.SFC<RootProps> = ({
         <Location>{pathname}</Location>
         <button onClick={(e) => handleClickNavigate(e, '/')}>/</button>
         <button onClick={(e) => handleClickNavigate(e, '/foo')}>foo</button>
+        <button onClick={(e) => handleClickNavigate(e, '/graphql')}>graphql</button>
       </NavBar>
-      <InitialState>
-        <p>Initial State</p>
-        <p>{number}</p>
-      </InitialState>
-      <div>
-        <p>static file</p>
-        <p><img src="/favicon-256.png" alt=""/></p>
-      </div>
-      <div>
-        count
-        <Count>
-          {count}
-        </Count>
-        <button onClick={(e) => handleClickAdd(e, {})}>
-          add
-        </button>
-      </div>
+      {createRoutes(rootRoutes)}
     </StyledRoot>
   );
 };
 
-Root.defaultProps = {
-  count: 0,
-};
+export default Root;
 
 interface RootProps {
-  count: number,
-  handleClickAdd: (e: React.SyntheticEvent, data: object) => void,
   handleClickNavigate: (e: React.SyntheticEvent, path: string) => void,
-  number: number,
   pathname: string,
 }
 
-export default Root;
+function createRoutes(routes: RouteEntry[]) {
+  return (
+    <Switch>
+      {
+        routes.map((r, idx) => {
+          return (
+            <Route
+              key={r.path || idx}
+              {...r}
+            />
+          );
+        })
+      }
+    </Switch>
+  );
+}

--- a/src/universal/components/app/Root/rootRotues.ts
+++ b/src/universal/components/app/Root/rootRotues.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import MainContainer from '@containers/app/MainContainer/MainContainer.web';
+import GraphQLContainer from '@containers/app/GraphQLContainer/GraphQLContainer.web';
+
+const rootRoutes: RouteEntry[] = [
+  {
+    path: '/graphql',
+    component: GraphQLContainer,
+  },
+  {
+    component: MainContainer,
+  },
+];
+
+export default rootRoutes;
+
+export interface RouteEntry {
+  path?: string,
+  component: React.ComponentType,
+}

--- a/src/universal/containers/app/GraphQLContainer/GraphQLContainer.web.tsx
+++ b/src/universal/containers/app/GraphQLContainer/GraphQLContainer.web.tsx
@@ -1,0 +1,34 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from "react-router-dom";
+
+import { ConnectedReduxProps } from '@universal/state/configureStore';
+
+class GraphQLContainer extends React.Component<GraphQLContainerProps> {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        123
+      </div>
+    );
+  }
+}
+
+const makeMapStateToProps = () => {
+  return (state, props) => {
+  };
+};
+
+interface GraphQLContainerProps extends ConnectedReduxProps, RouteComponentProps {
+}
+
+export default compose(
+  connect(makeMapStateToProps),
+)(GraphQLContainer);

--- a/src/universal/containers/app/MainContainer/MainContainer.web.tsx
+++ b/src/universal/containers/app/MainContainer/MainContainer.web.tsx
@@ -1,0 +1,51 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from "react-router-dom";
+
+import { ConnectedReduxProps } from '@universal/state/configureStore';
+import { add, fetchFoo } from '@actions/someAction';
+import Main from '@components/app/Main/Main.web';
+
+class MainContainer extends React.Component<MainContainerProps> {
+  constructor(props) {
+    super(props);
+    this.handleClickAdd = this.handleClickAdd.bind(this);
+  }
+
+  handleClickAdd(e, data) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.dispatch(add());
+  }
+
+  render() {
+    return (
+      <Main
+        count={this.props.count}
+        handleClickAdd={this.handleClickAdd}
+        number={this.props.number}
+      />
+    );
+  }
+}
+
+const makeMapStateToProps = () => {
+  return (state, props) => {
+    return {
+      count: state.foo.count,
+      number: state.foo.number,
+    };
+  };
+};
+
+interface MainContainerProps extends ConnectedReduxProps, RouteComponentProps {
+  count: number,
+  number: number,
+}
+
+export default compose(
+  connect(makeMapStateToProps),
+)(MainContainer);

--- a/src/universal/containers/app/RootContainer/RootContainer.web.tsx
+++ b/src/universal/containers/app/RootContainer/RootContainer.web.tsx
@@ -18,7 +18,6 @@ class RootContainer extends React.Component<RootContainerProps> {
 
   constructor(props) {
     super(props);
-    this.handleClickAdd = this.handleClickAdd.bind(this);
     this.handleClickNavigate = this.handleClickNavigate.bind(this);
   }
 
@@ -30,12 +29,6 @@ class RootContainer extends React.Component<RootContainerProps> {
     console.log('Root did mount');
   }
 
-  handleClickAdd(e, data) {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.dispatch(add());
-  }
-
   handleClickNavigate(e, path) {
     e.preventDefault();
     e.stopPropagation();
@@ -45,31 +38,18 @@ class RootContainer extends React.Component<RootContainerProps> {
   render() {
     return (
       <Root
-        count={this.props.count}
-        handleClickAdd={this.handleClickAdd}
         handleClickNavigate={this.handleClickNavigate}
-        number={this.props.number}
-        pathname={this.props.location.pathname}/>
+        pathname={this.props.location.pathname}
+      />
     );
   }
 }
 
-const makeMapStateToProps = () => {
-  return (state, props) => {
-    return {
-      count: state.foo.count,
-      number: state.foo.number,
-    };
-  };
-};
-
 interface RootContainerProps extends ConnectedReduxProps, RouteComponentProps {
-  count: number,
-  number: number,
 }
 
 export default compose<any>(
   hot(module),
   withRouter,
-  connect(makeMapStateToProps),
+  connect(),
 )(RootContainer);


### PR DESCRIPTION
- `rootRoutes` is created, and the array of object defined therein serves
as Route.

Fixes https://github.com/eldeni/react-elden-boilerplate/issues/56