### PR TITLE
feat: create feke apollo-server which serves `/graphql` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-loader": "^8.0.4",
     "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-styled-components": "^1.8.0",
+    "cors": "^2.8.4",
     "css-loader": "^0.28.11",
     "del": "^3.0.0",
     "eslint": "^5.6.1",
@@ -86,7 +87,9 @@
     "build:prod": "NODE_ENV=production ./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:prod",
     "build:server": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server",
     "dev:local": "NODE_ENV=development yarn run build:server && NODE_ENV=development node ./dist/babel/server/server.js",
+    "dev:local:withtools": "npm-run-all --parallel dev:local start:tools",
     "lint": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js tslint",
+    "start:tools": "NODE_ENV=development node ./tools/graphql-server/graphqlServer.js",
     "start:prod": "NODE_ENV=production node ./dist/babel/server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "tsc": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js tsc"

--- a/src/client/client.tsx
+++ b/src/client/client.tsx
@@ -11,11 +11,12 @@ import configureStore from '@universal/state/configureStore';
 console.info('App (client.jsx) is running, NODE_ENV: %s', process.env.NODE_ENV);
 
 const appRoot = document.getElementById('app-root');
+const FAKE_GRAPHQL_SERVER_URL_LAUNCHED_AS_TOOLS = 'http://localhost:5010/graphql';
 
 const apolloClient = new ApolloClient({ 
   cache: new InMemoryCache(),
   link: createHttpLink({
-    uri: 'https://nx9zvp49q7.lp.gql.zone/graphql',
+    uri: FAKE_GRAPHQL_SERVER_URL_LAUNCHED_AS_TOOLS,
   }),
 });
 

--- a/src/server/serverApp/makeHtml.tsx
+++ b/src/server/serverApp/makeHtml.tsx
@@ -14,6 +14,8 @@ import Log, { expressLog } from '@server/modules/Log';
 import routes from '@universal/routes';
 import ServerApp from './ServerApp';
 
+const FAKE_GRAPHQL_SERVER_URL_LAUNCHED_AS_TOOLS = 'http://localhost:5010/graphql';
+
 const makeHtml: MakeHtml = async function ({
   entrypointBundles,
   requestUrl = '',
@@ -24,7 +26,7 @@ const makeHtml: MakeHtml = async function ({
     cache: new InMemoryCache(),
     link: createHttpLink({
       fetch,
-      uri: 'http://localhost:3010',
+      uri: FAKE_GRAPHQL_SERVER_URL_LAUNCHED_AS_TOOLS,
     }),
     ssrMode: true,
   });

--- a/src/universal/containers/app/GraphQLContainer/GraphQLContainer.web.tsx
+++ b/src/universal/containers/app/GraphQLContainer/GraphQLContainer.web.tsx
@@ -10,11 +10,11 @@ import { ConnectedReduxProps } from '@universal/state/configureStore';
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
 
-const GQL1 = gql`
-{
-  rates(currency: "USD") {
-    currency
-    rate
+const sampleGQLWhichShouldNotChange = gql`
+query getDeal ($id: Long!) {
+  deal(id: $id) {
+    id
+    title
   }
 }
 `;
@@ -27,11 +27,25 @@ class GraphQLContainer extends React.Component<GraphQLContainerProps> {
   render() {
     return (
       <div>
-        query
-        <Query query={GQL1}>
+        <Query 
+          variables={{
+            id: 557802,
+          }}
+          query={sampleGQLWhichShouldNotChange}
+        >
           {({ loading, error, data}) => {
-            console.log(12322, loading, error, data);
-            return <div>1</div>
+            return (
+              <div>
+                <div>
+                  <span>id: </span>
+                  <span>{data.deal && data.deal.id}</span>
+                </div>
+                <div>
+                  <span>title: </span>
+                  <span>{data.deal && data.deal.title}</span>
+                </div>
+              </div>
+            );
           }}
         </Query>
       </div>

--- a/tools/graphql-server/graphqlServer.js
+++ b/tools/graphql-server/graphqlServer.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const cors = require('cors');
+
+const PORT = 5010;
+
+const app = express();
+app.use(cors());
+app.post('/graphql', (req, res, next) => {
+  (function serveGraphQLResponseStaticDummy() {
+    res.send({
+      data:{
+        deal:{
+          id: 1,
+          title: 'someTitle',
+          '__typename': 'Deal',
+        },
+      },
+      errors: null,
+    });
+  })();
+});
+
+app.use((req, res, next) => {
+  res.end('URL does not match our API. Please check.');
+});
+
+app.listen(PORT, (err) => {
+  console.info(`graphql server listening on ${PORT}`);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,6 +2362,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
+  integrity sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -5671,7 +5679,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.X, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.X, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8309,7 +8317,7 @@ value-or-function@^3.0.0:
   resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
   integrity sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
- `npm-rum-all` is added as dependency to run two servers concurrently.
- `dev-local-withtools` launches both graphQLFakeServer and app server.

Fixes https://github.com/eldeni/react-elden-boilerplate/issues/59