### PR TITLE
feat: make graphql preload data before initial rendering of app

### DIFF
--- a/src/client/client.tsx
+++ b/src/client/client.tsx
@@ -14,7 +14,7 @@ const appRoot = document.getElementById('app-root');
 const FAKE_GRAPHQL_SERVER_URL_LAUNCHED_AS_TOOLS = 'http://localhost:5010/graphql';
 
 const apolloClient = new ApolloClient({ 
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache().restore(window['__APOLLO_STATE__']),
   link: createHttpLink({
     uri: FAKE_GRAPHQL_SERVER_URL_LAUNCHED_AS_TOOLS,
   }),

--- a/src/server/serverApp/makeHtml.tsx
+++ b/src/server/serverApp/makeHtml.tsx
@@ -1,6 +1,7 @@
 import ApolloClient from 'apollo-client';
 import { createHttpLink } from 'apollo-link-http';
 import fetch from 'node-fetch';
+import { getDataFromTree } from 'react-apollo';
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { Provider as ReduxProvider } from 'react-redux';
 import * as React from "react";
@@ -30,7 +31,6 @@ const makeHtml: MakeHtml = async function ({
     }),
     ssrMode: true,
   });
-  const apolloState = apolloClient.extract();
 
   const reduxStore = await createStoreAndPrefetchData({
     requestUrl,
@@ -44,7 +44,10 @@ const makeHtml: MakeHtml = async function ({
       reduxStore={reduxStore}
     />
   );
+
+  await getDataFromTree(appRoot);
   const appRootInString = renderToString(appRoot);
+  const apolloState = apolloClient.extract();
 
   expressLog.debug('makeHtml() with store: %j', reduxStore.getState());
   expressLog.debug('appRootInString: %s', appRootInString);


### PR DESCRIPTION
- getDataFromTree() is used to wait for the graphql transaction before
the server returns the initial markup.

Fixes https://github.com/eldeni/react-elden-boilerplate/issues/61